### PR TITLE
refactor(model) Removes not needed Model.prototype.update function

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -23,7 +23,7 @@ Model.prototype.get = function(pk, store) {
 	});
 };
 
-Model.prototype.create = function(obj, store) {
+Model.prototype.set = function(obj, store) {
 	obj = obj || {};
 	var that = this;
 	return new Promise(function(resolve, reject) {
@@ -32,20 +32,6 @@ Model.prototype.create = function(obj, store) {
 			return store.setEntry(instance);
 		}).then(function() {
 			resolve(this.instance);
-		}).catch(function(err) {
-			reject(err);
-		});
-	});
-};
-
-Model.prototype.update = function(obj, store) {
-	var that = this;
-	return new Promise(function(resolve, reject) {
-		that.schema.create(obj).then(function(instance) {
-			this.instance = instance;
-			return store.setEntry(obj);
-		}).then(function(updatedObj) {
-			return resolve(this.instance);
 		}).catch(function(err) {
 			reject(err);
 		});

--- a/lib/store.js
+++ b/lib/store.js
@@ -45,11 +45,11 @@ Store.prototype.get = function(modelName, query) {
 };
 
 Store.prototype.create = function(modelName, obj) {
-	return this.callModelFunction(modelName, 'create', obj);
+	return this.callModelFunction(modelName, 'set', obj);
 };
 
 Store.prototype.update = function(modelName, obj) {
-	return this.callModelFunction(modelName, 'update', obj);
+	return this.callModelFunction(modelName, 'set', obj);
 };
 
 Store.prototype.delete = function(modelName, query) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stormer",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "The flexible Node.js ORM",
   "main": "index.js",
   "directories": {

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -73,7 +73,7 @@ describe('Model Tests', function() {
 	
 	});
 
-	describe('Model.prototype.create() should', function() {
+	describe('Model.prototype.set() should', function() {
 
 		it('return an error if schema has failed to create new instance', function(done) {
 			var that = this;
@@ -81,7 +81,7 @@ describe('Model Tests', function() {
 
 			sandbox.stub(schema, 'create').returns(Promise.reject(new Error('Schema.prototype.create() failed')));
 
-			this.model.create(this.instance, this.mockStore).catch(function(err) {
+			this.model.set(this.instance, this.mockStore).catch(function(err) {
 				schema.create.calledOnce.should.be.true;
 				schema.create.calledWith(that.instance).should.be.true;
 				err.message.should.equal('Schema.prototype.create() failed');
@@ -89,14 +89,14 @@ describe('Model Tests', function() {
 			}).catch(done);
 		});
 
-		it('create and save a valid instance', function(done) {
+		it('save a valid instance', function(done) {
 			var that = this;
 			var schema = this.model.schema;
 
 			sandbox.stub(this.mockStore, 'setEntry').returns(Promise.resolve(this.instance));
 			sandbox.stub(schema, 'create').returns(Promise.resolve(this.instance));
 
-			this.model.create(this.instance, this.mockStore).then(function(createdInstance) {
+			this.model.set(this.instance, this.mockStore).then(function(createdInstance) {
 				that.mockStore.setEntry.calledOnce.should.be.true;	
 				that.mockStore.setEntry.calledWith(that.instance).should.be.true;
 				schema.create.calledOnce.should.be.true;

--- a/test/store.spec.js
+++ b/test/store.spec.js
@@ -41,13 +41,13 @@ describe('Store Tests', function() {
 		}).catch(done);
 	});
 
-	it('Store.prototype.create() should call Model.prototype.create()', function(done) {
+	it('Store.prototype.create() should call Model.prototype.set()', function(done) {
 		var store = new Store();
 		var fakeObj = { pk: '1234'};
 		var createSpy = sandbox.spy();
 
 		store.define('myModel', {});
-		store.models.myModel.create = createSpy;
+		store.models.myModel.set = createSpy;
 		store.create('myModel', fakeObj).then(function() {
 			createSpy.called.should.be.true;
 			createSpy.calledWith(fakeObj, store);
@@ -55,13 +55,13 @@ describe('Store Tests', function() {
 		}).catch(done);
 	});
 
-	it('Store.prototype.update() should call Model.prototype.update()', function(done) {
+	it('Store.prototype.update() should call Model.prototype.set()', function(done) {
 		var store = new Store();
 		var fakeObj = { pk: '1234'};
 		var updateSpy = sandbox.spy();
 
 		store.define('myModel', {});
-		store.models.myModel.update = updateSpy;
+		store.models.myModel.set = updateSpy;
 		store.update('myModel', fakeObj).then(function() {
 			updateSpy.called.should.be.true;
 			updateSpy.calledWith(fakeObj, store);


### PR DESCRIPTION
Model.prototype had two functions:
- `create` 
- `update`

which they basically did the exact same thing. So I refactored the code to remove one of them and rename the other so we can reuse them. 

_Note_: This change doesn't affect the external API so it's not a breaking change.
