### PR TITLE
Feature: Differentiate update from create

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -11,6 +11,7 @@ var Model = function(schema) {
 };
 
 Model.prototype.get = function(pk, store) {
+	console.log(pk);
 	return new Promise(function(resolve, reject) {
 		store.getEntry(pk).then(function(obj) {
 			if (!obj) {
@@ -23,13 +24,13 @@ Model.prototype.get = function(pk, store) {
 	});
 };
 
-Model.prototype.set = function(obj, store) {
+Model.prototype.set = function(obj, operation, store) {
 	obj = obj || {};
 	var that = this;
 	return new Promise(function(resolve, reject) {
 		that.schema.create(obj).then(function(instance) {
 			this.instance = instance;
-			return store.setEntry(instance);
+			return store.setEntry(instance, operation);
 		}).then(function() {
 			resolve(this.instance);
 		}).catch(function(err) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -11,7 +11,6 @@ var Model = function(schema) {
 };
 
 Model.prototype.get = function(pk, store) {
-	console.log(pk);
 	return new Promise(function(resolve, reject) {
 		store.getEntry(pk).then(function(obj) {
 			if (!obj) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -33,7 +33,8 @@ Store.prototype.callModelFunction = function(modelName, funcName, args) {
 			if (typeof func !== 'function') {
 				return reject(new Error(util.format('Property %s of %s is not a function', funcName, modelName)));
 			}
-			resolve(model[funcName].call(model, args, that));
+			args.push(that); // Store is the last argument
+			resolve(model[funcName].apply(model, args));
 		}).catch(function(err) {
 			reject(err);
 		});
@@ -41,19 +42,19 @@ Store.prototype.callModelFunction = function(modelName, funcName, args) {
 };
 
 Store.prototype.get = function(modelName, query) {
-	return this.callModelFunction(modelName, 'get', query);
+	return this.callModelFunction(modelName, 'get', [query]);
 };
 
 Store.prototype.create = function(modelName, obj) {
-	return this.callModelFunction(modelName, 'set', obj);
+	return this.callModelFunction(modelName, 'set', [obj, 'create']);
 };
 
 Store.prototype.update = function(modelName, obj) {
-	return this.callModelFunction(modelName, 'set', obj);
+	return this.callModelFunction(modelName, 'set', [obj, 'update']);
 };
 
 Store.prototype.delete = function(modelName, query) {
-	return this.callModelFunction(modelName, 'delete', query);
+	return this.callModelFunction(modelName, 'delete', [query]);
 };
 
 /**
@@ -75,8 +76,8 @@ Store.prototype.getEntry = function(query) {
  * @return {Promise} - A Promise
  *
  */
-Store.prototype.setEntry = function(obj) {
-	return Promise.reject(new Error('Store.prototype.setEntry(obj) is not implemented'));
+Store.prototype.setEntry = function(obj, operation) {
+	return Promise.reject(new Error('Store.prototype.setEntry(obj, operation) is not implemented'));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stormer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The flexible Node.js ORM",
   "main": "index.js",
   "directories": {

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -96,7 +96,7 @@ describe('Model Tests', function() {
 			sandbox.stub(this.mockStore, 'setEntry').returns(Promise.resolve(this.instance));
 			sandbox.stub(schema, 'create').returns(Promise.resolve(this.instance));
 
-			this.model.set(this.instance, this.mockStore).then(function(createdInstance) {
+			this.model.set(this.instance, false, this.mockStore).then(function(createdInstance) {
 				that.mockStore.setEntry.calledOnce.should.be.true;	
 				that.mockStore.setEntry.calledWith(that.instance).should.be.true;
 				schema.create.calledOnce.should.be.true;

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -81,7 +81,7 @@ describe('Model Tests', function() {
 
 			sandbox.stub(schema, 'create').returns(Promise.reject(new Error('Schema.prototype.create() failed')));
 
-			this.model.set(this.instance, this.mockStore).catch(function(err) {
+			this.model.set(this.instance, 'create', this.mockStore).catch(function(err) {
 				schema.create.calledOnce.should.be.true;
 				schema.create.calledWith(that.instance).should.be.true;
 				err.message.should.equal('Schema.prototype.create() failed');
@@ -96,7 +96,7 @@ describe('Model Tests', function() {
 			sandbox.stub(this.mockStore, 'setEntry').returns(Promise.resolve(this.instance));
 			sandbox.stub(schema, 'create').returns(Promise.resolve(this.instance));
 
-			this.model.set(this.instance, false, this.mockStore).then(function(createdInstance) {
+			this.model.set(this.instance, 'create', this.mockStore).then(function(createdInstance) {
 				that.mockStore.setEntry.calledOnce.should.be.true;	
 				that.mockStore.setEntry.calledWith(that.instance).should.be.true;
 				schema.create.calledOnce.should.be.true;

--- a/test/store.spec.js
+++ b/test/store.spec.js
@@ -36,7 +36,7 @@ describe('Store Tests', function() {
 		store.models.myModel.get = getSpy;
 		store.get('myModel', pk).then(function() {
 			getSpy.called.should.be.true;
-			getSpy.calledWith(pk, store);
+			getSpy.calledWith(pk, store).should.be.true;
 			done();
 		}).catch(done);
 	});
@@ -50,7 +50,7 @@ describe('Store Tests', function() {
 		store.models.myModel.set = createSpy;
 		store.create('myModel', fakeObj).then(function() {
 			createSpy.called.should.be.true;
-			createSpy.calledWith(fakeObj, store);
+			createSpy.calledWith(fakeObj, 'create', store).should.be.true;
 			done();
 		}).catch(done);
 	});
@@ -64,7 +64,7 @@ describe('Store Tests', function() {
 		store.models.myModel.set = updateSpy;
 		store.update('myModel', fakeObj).then(function() {
 			updateSpy.called.should.be.true;
-			updateSpy.calledWith(fakeObj, store);
+			updateSpy.calledWith(fakeObj, 'update', store).should.be.true;
 			done();
 		}).catch(done);
 	});
@@ -78,7 +78,7 @@ describe('Store Tests', function() {
 		store.models.myModel.delete = deleteSpy;
 		store.delete('myModel', pk).then(function() {
 			deleteSpy.called.should.be.true;
-			deleteSpy.calledWith(pk, store);
+			deleteSpy.calledWith(pk, store).should.be.true;
 			done();
 		}).catch(done);
 	});


### PR DESCRIPTION
We need this to let the end user know if the setEntry functions is called from an `update` or `create` method. The user might want to avoid duplicates in create for example.
