### PR TITLE
feat(alias) Add alias function to model name definition

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -4,7 +4,7 @@ var Model = require('./model');
 
 var getModel = function(store, modelName) {
 	return new Promise(function(resolve, reject) {
-		var model = store.models[modelName];
+		var model = store.models[store.alias(modelName)];
 		if (!model) {
 			return reject(new Error(util.format('Model %s is not defined', modelName)));
 		}
@@ -16,9 +16,13 @@ var Store = function() {
 	this.models = {};
 };
 
+Store.prototype.alias = function(name) {
+  return name;
+};
+
 Store.prototype.define = function(modelName, schema) {
-	this.models[modelName] = new Model(schema);
-	return this.models[modelName];
+	this.models[this.alias(modelName)] = new Model(schema);
+	return this.models[this.alias(modelName)];
 };
 
 Store.prototype.callModelFunction = function(modelName, funcName, args) {

--- a/test/store.spec.js
+++ b/test/store.spec.js
@@ -2,6 +2,7 @@ var chai = require('chai');
 var sinon = require('sinon');
 var Store = require('../lib/store');
 var Model = require('../lib/model');
+var util = require('util');
 chai.should();
 
 var sandbox = sinon.sandbox.create();
@@ -82,5 +83,20 @@ describe('Store Tests', function() {
 			done();
 		}).catch(done);
 	});
+
+  it('Store.prototype.alias() should decoreate model name', function(done) {
+    var store = new Store();
+    store.alias = function(name) {
+      return util.format('%s.%s', 'test', name);
+    };
+    var expected = 'test.x';
+    var actual = store.alias('x');
+    expected.should.equal(actual);
+
+    store.define('myModel', {});
+		store.models.should.have.property('test.myModel');
+    store.models['test.myModel'].should.be.an.instanceOf(Model);
+    done();
+  });
 	
 });


### PR DESCRIPTION
Add a functionality to alias the store name without affecting the our code. This comes handy to avoid name conflicts (eg. using dynamodb as storage and want to prefix the table name).
