### PR TITLE
feat(cache): Add internal cache to stomer

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ store.get('users', {
 });
 ```
 
+### Internal Caching
+
+Store supports internal caching. In order to get this functionality up and running you need to implement the Cache interface found in `lib/cache.js` and pass an instance of your implementation upon Store instastiation. Example:
+
+```javascript
+var cache = new MyCache({ ttl: 12450, other: 'options' });
+var store = new Store(cache);
+```
+
+Store use the Cache upon create/update & get of objects. **Attention**: Store.delete does not clean item from cache. You need to relly on ttl for this.
+
 ## Schemas
 
 ### Define a primary key

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ var cache = new MyCache({ ttl: 12450, other: 'options' });
 var store = new Store(cache);
 ```
 
-Store use the Cache upon create/update & get of objects. **Attention**: Store.delete does not clean item from cache. You need to relly on ttl for this.
+Store use the Cache upon create/update & get of objects. **Attention**: Store.delete does not clean item from cache. You need to rely on ttl for this.
 
 ## Schemas
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -10,10 +10,6 @@ Cache.prototype.set = function(key, _) {
 	return false;
 };
 
-Cache.prototype.has = function(key) {
-	return false;
-};
-
 Cache.prototype.delete = function(key) {
 	return false;
 };

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,21 @@
+function Cache(options) {
+	this.options = options;
+};
+
+Cache.prototype.get = function(key) {
+ return null;
+};
+
+Cache.prototype.set = function(key, _) { 
+	return false;
+};
+
+Cache.prototype.has = function(key) {
+	return false;
+};
+
+Cache.prototype.delete = function(key) {
+	return false;
+};
+
+module.exports = Cache;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -76,6 +76,10 @@ var Schema = function(schema) {
 	this.primaryKey = primaryKey.pop();
 };
 
+Schema.prototype.getPkOfInstance = function(instance){
+	return instance[this.primaryKey] || null;
+};
+
 Schema.prototype.create = function(obj, schema){
 	var that = this;
 	var instance = {};

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,8 +1,19 @@
 var Promise = require('bluebird');
 var util = require('util');
 var Schema = require('./schema');
+var Cache = require('./cache');
 
-var Store = function() {
+function cacheKey(model, pk) {
+		return util.format('%s:%s', model, pk);
+};
+
+function Store(cache) {
+	if (cache instanceof Cache) {
+		this.cache = cache;
+		this.cacheEnabled = true;
+	} else {
+		this.cacheEnabled = false;
+	}
 	this.models = {};
 };
 
@@ -26,8 +37,16 @@ Store.prototype.getModel = function(modelName) {
 };
 
 Store.prototype.get = function(modelName, pk) {
+	var key = cacheKey(modelName, pk);
+	if (this.cacheEnabled && this.cache.has(key)) {
+		return this.cache.get(key);
+	}
 	var model = this.getModel(modelName);
-	return this._get(model, pk);
+	var instance = this._get(model, pk);
+	if (this.cacheEnabled) {
+		this.cache.set(key, instance);
+	}
+	return instance;
 };
 
 Store.prototype.filter = function(modelName, query) {
@@ -40,7 +59,13 @@ Store.prototype.create = function(modelName, obj) {
 	var that = this;
 	var model = this.getModel(modelName);
 	return model.schema.create(obj).then(function(instance) {
-		return that._set(model, instance, 'create');
+		var promise = that._set(model, instance, 'create');
+		var pk = model.schema.getPkOfInstance(instance);
+		if (that.cacheEnabled && pk !== null) {
+			var key = cacheKey(modelName, pk);
+			that.cache.set(key, promise);
+		}
+		return promise;
 	});
 };
 
@@ -48,8 +73,15 @@ Store.prototype.update = function(modelName, obj) {
 	obj = obj || {};
 	var that = this;
 	var model = this.getModel(modelName);
+
 	return model.schema.create(obj).then(function(instance) {
-		return that._set(model, instance, 'update');
+		var promise = that._set(model, instance, 'update');
+		var pk = model.schema.getPkOfInstance(instance);
+		if (that.cacheEnabled && pk !== null) {
+			var key = cacheKey(modelName, pk);
+			that.cache.set(key, promise);
+		}
+		return promise;
 	});
 };
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -8,12 +8,7 @@ function cacheKey(model, pk) {
 };
 
 function Store(cache) {
-	if (cache instanceof Cache) {
-		this.cache = cache;
-		this.cacheEnabled = true;
-	} else {
-		this.cacheEnabled = false;
-	}
+	this.cache = (cache instanceof Cache) ? cache : false;
 	this.models = {};
 };
 
@@ -38,12 +33,12 @@ Store.prototype.getModel = function(modelName) {
 
 Store.prototype.get = function(modelName, pk) {
 	var key = cacheKey(modelName, pk);
-	if (this.cacheEnabled && this.cache.has(key)) {
-		return this.cache.get(key);
+	if (this.cache && (cached=this.cache.get(key))) {
+		return cached;
 	}
 	var model = this.getModel(modelName);
 	var instance = this._get(model, pk);
-	if (this.cacheEnabled) {
+	if (this.cache) {
 		this.cache.set(key, instance);
 	}
 	return instance;
@@ -54,35 +49,28 @@ Store.prototype.filter = function(modelName, query) {
 	return this._filter(model, query);
 };
 
-Store.prototype.create = function(modelName, obj) {
-	obj = obj || {};
-	var that = this;
-	var model = this.getModel(modelName);
-	return model.schema.create(obj).then(function(instance) {
-		var promise = that._set(model, instance, 'create');
+function afterCreate(action, modelName, model) {
+	return function(instance) {
+		var promise = this._set(model, instance, action);
 		var pk = model.schema.getPkOfInstance(instance);
-		if (that.cacheEnabled && pk !== null) {
+		if (this.cache && pk !== null) {
 			var key = cacheKey(modelName, pk);
-			that.cache.set(key, promise);
+			this.cache.set(key, promise);
 		}
 		return promise;
-	});
+	};
+};
+
+Store.prototype.create = function(modelName, obj) {
+	obj = obj || {};
+	var model = this.getModel(modelName);
+	return model.schema.create(obj).then(afterCreate('create', modelName, model).bind(this));
 };
 
 Store.prototype.update = function(modelName, obj) {
 	obj = obj || {};
-	var that = this;
 	var model = this.getModel(modelName);
-
-	return model.schema.create(obj).then(function(instance) {
-		var promise = that._set(model, instance, 'update');
-		var pk = model.schema.getPkOfInstance(instance);
-		if (that.cacheEnabled && pk !== null) {
-			var key = cacheKey(modelName, pk);
-			that.cache.set(key, promise);
-		}
-		return promise;
-	});
+	return model.schema.create(obj).then(afterCreate('update', modelName, model).bind(this));
 };
 
 Store.prototype.delete = function(modelName, query) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stormer",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The flexible Node.js ORM",
   "main": "index.js",
   "directories": {

--- a/test/mock/mycache.js
+++ b/test/mock/mycache.js
@@ -16,12 +16,8 @@ MyCache.prototype.set = function(key, obj) {
 	return this._internal.set(key, obj);
 };
 
-MyCache.prototype.has = function(key) {
-	return this._internal.has(key);
-};
-
 MyCache.prototype.delete = function(key) {
-	return this._internal.delete(key);;
+	return this._internal.delete(key);
 };
 
 module.exports = MyCache;

--- a/test/mock/mycache.js
+++ b/test/mock/mycache.js
@@ -1,0 +1,27 @@
+var Cache = require('../../lib/cache');
+var util = require('util');
+
+function MyCache() {
+	Cache.call(this);
+	this._internal = new Map();
+};
+
+util.inherits(MyCache, Cache);
+
+MyCache.prototype.get = function(key) {
+	return this._internal.get(key);
+};
+
+MyCache.prototype.set = function(key, obj) { 
+	return this._internal.set(key, obj);
+};
+
+MyCache.prototype.has = function(key) {
+	return this._internal.has(key);
+};
+
+MyCache.prototype.delete = function(key) {
+	return this._internal.delete(key);;
+};
+
+module.exports = MyCache;

--- a/test/schema.spec.js
+++ b/test/schema.spec.js
@@ -475,5 +475,31 @@ describe('Schema Tests', function() {
 		});
 
 	});
+
+	describe('Schema.prototype.getPkOfInstance should', function() {
+
+		it('return null if not primary key is set for schema', function(done) {
+			var schema = new Schema({ pk: 'String' });
+			(schema.getPkOfInstance({}) === null).should.equal(true);
+			(schema.getPkOfInstance({ pk: '12345' }) === null).should.equal(true);
+			done();
+		});
+
+		it('return null instance has no primary key', function(done) {
+			var schema = new Schema({ pk: { type: 'String', primaryKey: true } });
+			(schema.getPkOfInstance({}) ===  null).should.equal(true);
+			(schema.getPkOfInstance({ foo: '12345' }) === null).should.equal(true);
+			done();
+		});
+
+		it('return primary key of instance', function(done) {
+			var schema = new Schema({ pk: { type: 'String', primaryKey: true } });
+			schema.getPkOfInstance({ pk: '12345' }).should.equal('12345');
+			(schema.getPkOfInstance({ pk: null }) === null).should.equal(true);
+			(schema.getPkOfInstance({ pk: undefined }) === null).should.equal(true);
+			done();
+		});
+
+	});
 	
 });

--- a/test/store.spec.js
+++ b/test/store.spec.js
@@ -1,6 +1,7 @@
 var chai = require('chai');
 var sinon = require('sinon');
 var Store = require('../lib/store');
+var MyCache = require('./mock/mycache');
 chai.should();
 
 var sandbox = sinon.sandbox.create();
@@ -62,7 +63,7 @@ describe('Store Tests', function() {
 		var fakeObj = { pk: '1234'};
 		var createStub = sandbox.stub(store, '_set').returns(Promise.resolve());
 
-		var model = store.define('myModel', { pk: 'String' });
+		var model = store.define('myModel', { pk: { type: 'String', primaryKey: true } });
 		store.create('myModel', fakeObj).then(function() {
 			createStub.called.should.be.true;
 			createStub.calledWith(model, fakeObj, 'create').should.be.true;
@@ -74,7 +75,7 @@ describe('Store Tests', function() {
 		var fakeObj = { pk: '1234'};
 		var updateSpy = sandbox.stub(store, '_set').returns(Promise.resolve());
 
-		var model = store.define('myModel', { pk: 'String' });
+		var model = store.define('myModel', { pk: { type: 'String', primaryKey: true } });
 		store.update('myModel', fakeObj).then(function() {
 			updateSpy.called.should.be.true;
 			updateSpy.calledWith(model, fakeObj, 'update').should.be.true;
@@ -92,6 +93,110 @@ describe('Store Tests', function() {
 			deleteSpy.calledWith(model, pk).should.be.true;
 			done();
 		}).catch(done);
+	});
+
+	it('Store.prototype._filter() should return a Promise rejected', function(done) {
+		store._filter().catch(function(err) {
+			err.message.should.equal('Store.prototype._filter(model, query) is not implemented');
+			done();
+		});
+	});
+
+	it('Store.prototype._get() should return a Promise rejected', function(done) {
+		store._get().catch(function(err) {
+			err.message.should.equal('Store.prototype._get(model, pk) is not implemented');
+			done();
+		});
+	});
+
+	it('Store.prototype._set() should return a Promise rejected', function(done) {
+		store._set().catch(function(err) {
+			err.message.should.equal('Store.prototype._set(model, obj, operation) is not implemented');
+			done();
+		});
+	});
+
+	it('Store.prototype._delete() should return a Promise rejected', function(done) {
+		store._delete().catch(function(err) {
+			err.message.should.equal('Store.prototype._delete(query) is not implemented');
+			done();
+		});
+	});
+
+	describe('Cache Integration should', function() {
+
+		var cache;
+
+		beforeEach(function() {
+			cache = new MyCache();
+		});
+
+		it('have cacheEnabled true', function(done) {
+			var store = new Store();
+			store.cacheEnabled.should.equal(false);
+
+			var store = new Store(cache);
+			store.cacheEnabled.should.equal(true);
+			store.cache.should.equal(cache);
+			done();
+		});
+
+		it('return from cache when get', function(done) {
+			var store = new Store(cache);
+
+			var pk = '1234';
+			var instance = Promise.resolve({ foo: 'bar' });
+			var getStub = sandbox.stub(store, '_get').returns(instance);
+
+			var model = store.define('myModel', {});
+
+			store.get('myModel', pk).then(function(expected) {
+				store.get('myModel', pk).then(function(actual) {
+					(getStub.calledOnce == true).should.equal(true);
+					(getStub.calledWith(model, pk) == true).should.equal(true);
+					actual.should.equal(expected);
+					done();
+				}).catch(done);
+			}).catch(done);
+		});
+
+		it('set to cache when create', function(done) {
+			var obj = { pk: '1234' };
+			var resolved = Promise.resolve(obj);
+
+			var store = new Store(cache);
+			var model = store.define('myModel', { pk: { type: 'String', primaryKey: true } });
+
+			var createStub = sandbox.stub(store, '_set').returns(resolved);
+			var getStub = sandbox.stub(store, '_get').returns(resolved);
+
+			store.create('myModel', obj).then(function(actual) {
+				store.get('myModel', obj.pk).then(function(expected) {
+					(getStub.called === false).should.equal(true);
+					expected.should.equal(actual);
+					done();
+				}).catch(done);
+			}).catch(done);
+		});
+
+		it('set to cache when update', function(done) {
+			var obj = { pk: '1234' };
+			var resolved = Promise.resolve(obj);
+
+			var store = new Store(cache);
+			var model = store.define('myModel', { pk: { type: 'String', primaryKey: true } });
+
+			var createStub = sandbox.stub(store, '_set').returns(resolved);
+			var getStub = sandbox.stub(store, '_get').returns(resolved);
+
+			store.update('myModel', obj).then(function(actual) {
+				store.get('myModel', obj.pk).then(function(expected) {
+					(getStub.called === false).should.equal(true);
+					expected.should.equal(actual);
+					done();
+				}).catch(done);
+			}).catch(done);
+		});
 	});
 	
 });

--- a/test/store.spec.js
+++ b/test/store.spec.js
@@ -131,12 +131,11 @@ describe('Store Tests', function() {
 			cache = new MyCache();
 		});
 
-		it('have cacheEnabled true', function(done) {
+		it('have cache objext', function(done) {
 			var store = new Store();
-			store.cacheEnabled.should.equal(false);
+			store.cache.should.equal(false);
 
 			var store = new Store(cache);
-			store.cacheEnabled.should.equal(true);
 			store.cache.should.equal(cache);
 			done();
 		});
@@ -172,7 +171,7 @@ describe('Store Tests', function() {
 
 			store.create('myModel', obj).then(function(actual) {
 				store.get('myModel', obj.pk).then(function(expected) {
-					(getStub.called === false).should.equal(true);
+					getStub.called.should.equal(false);
 					expected.should.equal(actual);
 					done();
 				}).catch(done);
@@ -191,7 +190,7 @@ describe('Store Tests', function() {
 
 			store.update('myModel', obj).then(function(actual) {
 				store.get('myModel', obj.pk).then(function(expected) {
-					(getStub.called === false).should.equal(true);
+					getStub.called.should.equal(false);
 					expected.should.equal(actual);
 					done();
 				}).catch(done);


### PR DESCRIPTION
Add internal caching functionality to store. Store uses a `Cache` instance provided upon construction and use simple get/set methods to cache and invalidate cached data.

Pull request consist of `Cache` interface as long `Store` internal implementation changes and tests.
